### PR TITLE
Refactor Socket.arguments, attend to deprecation warnings + bump dependencies 

### DIFF
--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -177,57 +177,31 @@ defmodule Socket do
         [{ :active, false } | args]
     end
 
-    args = if Keyword.has_key?(options, :route) do
-      [{ :dontroute, !Keyword.get(options, :route) } | args]
-    else
-      args
-    end
+    # args = if Keyword.has_key?(options, :route) do
+    #   [{ :dontroute, !Keyword.get(options, :route) } | args]
+    # else
+    #   args
+    # end
 
-    args = if Keyword.get(options, :reuseaddr) do
-      [{ :reuseaddr, true } | args]
-    else
-      args
-    end
-
-    args = if linger = Keyword.get(options, :linger) do
-      [{ :linger, { true, linger } } | args]
-    else
-      args
-    end
-
-    args = if priority = Keyword.get(options, :priority) do
-      [{ :priority, priority } | args]
-    else
-      args
-    end
-
-    args = if tos = Keyword.get(options, :tos) do
-      [{ :tos, tos } | args]
-    else
-      args
-    end
+    args = args
+    |> add_option(options, :route, { :dontroute, !Keyword.get(options, :route) })
+    |> add_option(options, :reuseaddr, { :reuseaddr, true })
+    |> add_option(options, :linger, { :linger, { true, Keyword.get(options, :linger) } })
+    |> add_option(options, :priority, { :priority, Keyword.get(options, :priority) })
+    |> add_option(options, :tos, { :tos, Keyword.get(options, :tos) })
 
     args = if send = Keyword.get(options, :send) do
       args = case Keyword.get(send, :timeout) do
         { timeout, :close } ->
           [{ :send_timeout, timeout }, { :send_timeout_close, true } | args]
 
-        timeout when timeout |> is_integer ->
+        timeout when is_integer(timeout) ->
           [{ :send_timeout, timeout } | args]
       end
 
-      args = if delay = Keyword.get(send, :delay) do
-        [{ :delay_send, delay } | args]
-      else
-        args
-      end
-
-      args = if buffer = Keyword.get(send, :buffer) do
-        [{ :sndbuf, buffer } | args]
-      else
-        args
-      end
-      args
+      args = args
+      |> add_option(send, :delay, { :delay_send, Keyword.get(send, :delay) })
+      |> add_option(send, :buffer, { :sndbuf, Keyword.get(send, :buffer) })
     else
       args
     end
@@ -238,6 +212,14 @@ defmodule Socket do
       else
         args
       end
+    else
+      args
+    end
+  end
+
+  defp add_option(args, options, option, config) do
+    if Keyword.has_key?(options, option) do
+      [config | args]
     else
       args
     end

--- a/lib/socket/web.ex
+++ b/lib/socket/web.ex
@@ -813,7 +813,7 @@ defmodule Socket.Web do
   """
   @spec ping(t)         :: :ok | { :error, error }
   @spec ping(t, binary) :: :ok | { :error, error }
-  def ping(self, cookie \\ :crypto.rand_bytes(32)) do
+  def ping(self, cookie \\ :crypto.strong_rand_bytes(32)) do
     case send(self, { :ping, cookie }) do
       :ok ->
         cookie
@@ -828,7 +828,7 @@ defmodule Socket.Web do
   """
   @spec ping!(t)         :: :ok | no_return
   @spec ping!(t, binary) :: :ok | no_return
-  def ping!(self, cookie \\ :crypto.rand_bytes(32)) do
+  def ping!(self, cookie \\ :crypto.strong_rand_bytes(32)) do
     send!(self, { :ping, cookie })
 
     cookie

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,2 @@
-%{"ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/socket_test.exs
+++ b/test/socket_test.exs
@@ -1,0 +1,61 @@
+defmodule SocketTest do
+  use ExUnit.Case, async: true
+
+  test "default options" do
+    args = Socket.arguments([])
+    assert args == [active: false]
+  end
+
+  test "route option" do
+    args = Socket.arguments([route: true])
+    assert Keyword.get(args, :dontroute) == false
+  end
+
+  test "reuseaddr option" do
+    args = Socket.arguments([reuseaddr: true])
+    assert Keyword.get(args, :reuseaddr) == true
+  end
+
+  test "linger option" do
+    args = Socket.arguments([linger: true])
+    assert Keyword.get(args, :linger) == { true, true }
+  end
+
+  test "priority option" do
+    args = Socket.arguments([priority: 1])
+    assert Keyword.get(args, :priority) == 1
+  end
+
+  test "tos option" do
+    args = Socket.arguments([tos: 1])
+    assert Keyword.get(args, :tos) == 1
+  end
+
+  test "send timeout option" do
+    args = Socket.arguments([send: [timeout: 5]])
+    assert Keyword.get(args, :send_timeout) == 5
+  end
+
+  test "send timeout option with close" do
+    args = Socket.arguments([send: [timeout: { 5, :close }]])
+    assert Keyword.get(args, :send_timeout) == 5
+    assert Keyword.get(args, :send_timeout_close)
+  end
+
+  test "send delay + timeout options" do
+    args = Socket.arguments([send: [timeout: 5, delay: true]])
+    assert Keyword.get(args, :send_timeout) == 5
+    assert Keyword.get(args, :delay_send)
+  end
+
+  test "buffer + timeout options" do
+    args = Socket.arguments([send: [timeout: 5, buffer: 10]])
+    assert Keyword.get(args, :send_timeout) == 5
+    assert Keyword.get(args, :sndbuf) == 10
+  end
+
+  test "recv buffer option" do
+    args = Socket.arguments([recv: [buffer: 5]])
+    assert Keyword.get(args, :recbuf) == 5
+  end
+end


### PR DESCRIPTION
I noticed your PR on the elixir-socket project and I would like to add these few things to it:
- I use `:crypto.strong_rand_bytes` in two places, now that `:crypto.rand_bytes` has been deprecated. I think this happened in Elixir 1.3.
- I bumped the `ex_doc` dependency, as I noticed it was out of date and that there were warnings that sprung up when I compiled the project.
- I refactored `Socket.arguments` to remove a bit of the duplication in this. Prior to the refactoring I wrote some tests that asserted the existing behaviour in `Socket.arguments`. Those tests are now all passing after this refactor.
